### PR TITLE
Add envar partition support

### DIFF
--- a/board/kubos/pumpkin-mbm2/bootdev_detect.h
+++ b/board/kubos/pumpkin-mbm2/bootdev_detect.h
@@ -2,136 +2,141 @@
 #ifndef __BOOTDEV_DETECT_H
 #define __BOOTDEV_DETECT_H
 
-    #include <common.h>
-    #include <spl.h>
+#include <common.h>
+#include <spl.h>
 
-    DECLARE_GLOBAL_DATA_PTR;
+DECLARE_GLOBAL_DATA_PTR;
 
-    /* 
-        ------------------------------------------------------------------------
-        The AM335x processor has a register entry with an identifier for the 
-        boot device used at the last power-on boot (see spl.h for deivice 
-        definitions).  This is the device that will be used to search for the 
-        MBR and boot partition (partition 1) on all subsequent resets until 
-        there is a new full power-on boot.  The functions in this file, along 
-        with some configuration settings in pumpkin-mbm2.h, are intended to use 
-        this regiser value to override hard-coded device and partition settings 
-        for loading the U-Boot environment and the Kubos upgrade feature.  This
-        is useful for systems that want to have fully independent and redundant 
-        boot disks on the internal eMMC and micro-SD card that can be selected 
-        from an external GPIO signal using the SYS_BOOT2 line, which is exposed 
-        on the BeagleBone Black.
-        ------------------------------------------------------------------------        
-    */
+/*
+    ------------------------------------------------------------------------
+    The AM335x processor has a register entry with an identifier for the
+    boot device used at the last power-on boot (see spl.h for deivice
+    definitions).  This is the device that will be used to search for the
+    MBR and boot partition (partition 1) on all subsequent resets until
+    there is a new full power-on boot.  The functions in this file, along
+    with some configuration settings in pumpkin-mbm2.h, are intended to use
+    this regiser value to override hard-coded device and partition settings
+    for loading the U-Boot environment and the Kubos upgrade feature.  This
+    is useful for systems that want to have fully independent and redundant
+    boot disks on the internal eMMC and micro-SD card that can be selected
+    from an external GPIO signal using the SYS_BOOT2 line, which is exposed
+    on the BeagleBone Black.
+    ------------------------------------------------------------------------
+*/
 
-
-    /*   
-        Returns the power-on boot device number (if it was an MMC device).  Note 
-        that the mmc device number is one less than the defined flag names.
-    */
-    static inline int get_boot_mmc_device(void)
-    {    
-        switch (gd->arch.omap_boot_device) {
-            case BOOT_DEVICE_MMC1:
-                return 0;
-            case BOOT_DEVICE_MMC2:
-                return 1;
-        }
-        return -1;
+/*
+    Returns the power-on boot device number (if it was an MMC device).  Note
+    that the mmc device number is one less than the defined flag names.
+*/
+static inline int get_boot_mmc_device(void)
+{
+    switch (gd->arch.omap_boot_device)
+    {
+    case BOOT_DEVICE_MMC1:
+        return 0;
+    case BOOT_DEVICE_MMC2:
+        return 1;
     }
+    return -1;
+}
 
+/*
+    Provides a hook if you want to do custom logic to determine the mmc
+    device used for loading the U-Boot environment.  For now, we assume the
+    environment file is on the same device as used by the system boot.
+*/
+static inline int get_env_device(void)
+{
+    return get_boot_mmc_device();
+}
 
-    /* 
-        Provides a hook if you want to do custom logic to determine the mmc 
-        device used for loading the U-Boot environment.  For now, we assume the 
-        environment file is on the same device as used by the system boot.
-    */
-    static inline int get_env_device(void)
-    { 
-       return get_boot_mmc_device();      
-    }
+/*
+    Provides a hook if you want to do custom logic to determine the
+    partition used for loading the U-Boot environment file.  For now, we
+    assume the environment file is in the same partition on either mmc
+    device and return the defined value from pumpkin-mbm2.h.
+*/
+static inline int get_env_partition(void)
+{
+    return BOOTDEV_DETECT_ENV_PART;
+}
 
-    /* 
-        Provides a hook if you want to do custom logic to determine the 
-        partition used for loading the U-Boot environment file.  For now, we  
-        assume the environment file is in the same partition on either mmc 
-        device and return the defined value from pumpkin-mbm2.h.
-    */
-    static inline int get_env_partition(void)
-    { 
-       return BOOTDEV_DETECT_ENV_PART;      
-    }
+/* Similar to get_env_partition() above */
+static inline int get_boot_upgrade_partition(void)
+{
+    return BOOTDEV_DETECT_UPGRADE_PART;
+}
+
+/*
+    Convenience function to return a short string containing "dev:part"
+    (e.g. "1:3") for the environment location.
+*/
+static inline char *get_env_devpart(void)
+{
+    static char devpart[16];
+    snprintf(devpart, 16, "%d:%d", get_env_device(), get_env_partition());
+    return devpart;
+}
+
+/* Stores the detected boot device in a predefined environment parameter.
+   Optionally saves the environment to disk so this information is available
+   within in the booted linux.
+*/
+static inline void set_env_param_bootdev(void)
+{
+    char devstr[8];
+    snprintf(devstr, 8, "%d", get_env_device());
+
+    printf("Setting %s environment variable to %s\n",
+           BOOTDEV_DETECT_ENV_PARAM, devstr);
+    setenv(BOOTDEV_DETECT_ENV_PARAM, devstr);
+
+#ifdef BOOTDEV_DETECT_ENV_SAVE
+    printf("Saving environment\n");
+    saveenv();
+#endif
+}
+
+/*
+    ------------------------------------------------------------------------
+    If the Kubos Upgrade feature is enabled, add functions to return the
+    device and partition where the upgrade image (.itb) resides.
+    ------------------------------------------------------------------------
+*/
+#ifdef CONFIG_UPDATE_KUBOS
+
+/* Similar to get_env_device() above */
+static inline int get_upgrade_device(void)
+{
+    return get_boot_mmc_device();
+}
+
+/* Similar to get_env_partition() above */
+static inline int get_upgrade_partition(void)
+{
+    return KUBOS_UPGRADE_PART;
+}
+
+/*
+    Returns a string containing the dfu_alt_info_mmc information that
+    specifies the images to load from the upgrade .itb file and the
+    destinations.  Any instance of "%1$d" in the dfu_alt_info_mmc string
+    is replaced with the upgrade device number.
+*/
+static inline char *get_dfu_alt_info_mmc(void)
+{
+    static char dfu_info[256];
+    int upgrade_dev = get_upgrade_device();
 
     /*
-        Convenience function to return a short string containing "dev:part"
-        (e.g. "1:3") for the environment location.
-    */
-    static inline char *get_env_devpart(void)
-    {
-        static char devpart[16];
-        snprintf(devpart, 16, "%d:%d", get_env_device(), get_env_partition());
-        return devpart;
-    }
+     * We need three copies of upgrade_dev because U-Boot does not support the %1$
+     * syntax to "lock" everything to the first variable and we have 3 %1d's in our dfu_string
+     */
+    snprintf(dfu_info, 256, getenv("dfu_alt_info_mmc"), upgrade_dev, upgrade_dev, upgrade_dev);
 
-    /* Stores the detected boot device in a predefined environment parameter.
-       Optionally saves the environment to disk so this information is available
-       within in the booted linux.
-    */
-    static inline void set_env_param_bootdev(void)
-    {
-        char devstr[8];
-        snprintf(devstr, 8, "%d", get_env_device());  
-             
-        printf("Setting %s environment variable to %s\n", 
-            BOOTDEV_DETECT_ENV_PARAM, devstr);
-        setenv(BOOTDEV_DETECT_ENV_PARAM, devstr);
-        
-        #ifdef BOOTDEV_DETECT_ENV_SAVE
-            printf("Saving environment\n");
-            saveenv();
-        #endif
-    }
+    return dfu_info;
+}
 
-    /*
-        ------------------------------------------------------------------------
-        If the Kubos Upgrade feature is enabled, add functions to return the 
-        device and partition where the upgrade image (.itb) resides.
-        ------------------------------------------------------------------------
-    */
-    #ifdef CONFIG_UPDATE_KUBOS
-
-        /* Similar to get_env_device() above */
-        static inline int get_upgrade_device(void)
-        {
-            return get_boot_mmc_device();
-        } 
-
-        /* Similar to get_env_partition() above */
-        static inline int get_upgrade_partition(void)
-        {
-            return KUBOS_UPGRADE_PART;
-        }
-
-        /*
-            Returns a string containing the dfu_alt_info_mmc information that 
-            specifies the images to load from the upgrade .itb file and the 
-            destinations.  Any instance of "%1$d" in the dfu_alt_info_mmc string
-            is replaced with the upgrade device number.
-        */
-        static inline char* get_dfu_alt_info_mmc(void)
-        {
-            static char dfu_info[256];	    
-            int upgrade_dev = get_upgrade_device();
-
-            /*
-             * We need three copies of upgrade_dev because U-Boot does not support the %1$
-             * syntax to "lock" everything to the first variable and we have 3 %1d's in our dfu_string
-             */
-            snprintf(dfu_info, 256, getenv("dfu_alt_info_mmc"), upgrade_dev, upgrade_dev, upgrade_dev);
-
-            return dfu_info;
-        }
-
-    #endif /* CONFIG_UPDATE_KUBOS */
+#endif /* CONFIG_UPDATE_KUBOS */
 
 #endif /* __BOOTDEV_DETECT_H */

--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -296,7 +296,7 @@ int update_kubos(bool upgrade)
      * Get and mount the upgrade file partition
      */
 #ifdef CONFIG_BOOTDEV_DETECT
-    part = get_upgrade_partition();
+    part = get_boot_upgrade_partition();
 #else
     if ((env_addr = getenv(PART_ENVAR)) != NULL)
     {

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -56,7 +56,7 @@
 /* If using boot device detection instead of hard coded device info */
 #ifdef CONFIG_BOOTDEV_DETECT
 #define BOOTDEV_DETECT_ENV_PART 3              /* U-boot environment partition if using BOOTDEV_DETECT */
-#define BOOTDEV_DETECT_UPGRADE_PART 4          /* U-boot environment partition if using BOOTDEV_DETECT */
+#define BOOTDEV_DETECT_UPGRADE_PART 5          /* U-boot environment partition if using BOOTDEV_DETECT */
 #define BOOTDEV_DETECT_ENV_PARAM "boot_detect" /* U-boot environment parameter used to store the detected boot device*/
 #undef BOOTDEV_DETECT_ENV_SAVE                 /* Saves the environment back to disk after adding the detected boot device in PARAM */
 #endif

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -1,23 +1,23 @@
 /*
-* Copyright (C) 2017 Kubos Corporation
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* pumpkin-mbm2.h
-*
-* Configuration file for the Pumpkin Motherboard Module 2, using a Beaglebone Black
-* as the OBC.
-*/
+ * Copyright (C) 2017 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * pumpkin-mbm2.h
+ *
+ * Configuration file for the Pumpkin Motherboard Module 2, using a Beaglebone Black
+ * as the OBC.
+ */
 
 #pragma once
 
@@ -40,132 +40,131 @@
 
 /* If we're compiling for the SPL, we don't have an env area */
 #if defined(CONFIG_SPL_BUILD) && defined(CONFIG_SPL_USBETH_SUPPORT)
-    #define CONFIG_ENV_IS_NOWHERE
+#define CONFIG_ENV_IS_NOWHERE
 #else
-    /* Otherwise, it's in an ext4 partition */
-    #ifdef CONFIG_CMD_EXT4
-        #define CONFIG_EXT4_WRITE
-        #define CONFIG_ENV_IS_IN_EXT4       1
-        #define CONFIG_ENV_SIZE             10 * 1024 /* Assume sector size of 1024 */
-        #define EXT4_ENV_INTERFACE          "mmc"
-        #define EXT4_ENV_FILE               "/uboot.env"
-        #define EXT4_ENV_DEVICE_AND_PART    "1:3" /* U-boot environment location (dev:part) if _not_ using BOOTDEV_DETECT */
-    #endif
+/* Otherwise, it's in an ext4 partition */
+#ifdef CONFIG_CMD_EXT4
+#define CONFIG_EXT4_WRITE
+#define CONFIG_ENV_IS_IN_EXT4 1
+#define CONFIG_ENV_SIZE 10 * 1024 /* Assume sector size of 1024 */
+#define EXT4_ENV_INTERFACE "mmc"
+#define EXT4_ENV_FILE "/uboot.env"
+#define EXT4_ENV_DEVICE_AND_PART "1:3" /* U-boot environment location (dev:part) if _not_ using BOOTDEV_DETECT */
+#endif
 #endif /* CONFIG_SPL_BUILD */
 
 /* If using boot device detection instead of hard coded device info */
 #ifdef CONFIG_BOOTDEV_DETECT
-    #define BOOTDEV_DETECT_ENV_PART    3 /* U-boot environment partition if using BOOTDEV_DETECT */
-    #define BOOTDEV_DETECT_ENV_PARAM   "boot_detect" /* U-boot environment parameter used to store the detected boot device*/
-    #undef BOOTDEV_DETECT_ENV_SAVE     /* Saves the environment back to disk after adding the detected boot device in PARAM */  
+#define BOOTDEV_DETECT_ENV_PART 3              /* U-boot environment partition if using BOOTDEV_DETECT */
+#define BOOTDEV_DETECT_UPGRADE_PART 4          /* U-boot environment partition if using BOOTDEV_DETECT */
+#define BOOTDEV_DETECT_ENV_PARAM "boot_detect" /* U-boot environment parameter used to store the detected boot device*/
+#undef BOOTDEV_DETECT_ENV_SAVE                 /* Saves the environment back to disk after adding the detected boot device in PARAM */
 #endif
 
 /* If using Kubos system updates feature */
 #ifdef CONFIG_UPDATE_KUBOS
-    #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
-    #define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently kernel (~2.5M) */
-    #define KUBOS_UPGRADE_DEVICE 0
-    #define KUBOS_UPGRADE_PART   1
-    #define KUBOS_UPGRADE_STORAGE CONFIG_SYS_LOAD_ADDR /* Temporary SDRAM storage location */
+#define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
+#define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently kernel (~2.5M) */
+#define KUBOS_UPGRADE_DEVICE 0
+#define KUBOS_UPGRADE_PART 1
+#define KUBOS_UPGRADE_STORAGE CONFIG_SYS_LOAD_ADDR /* Temporary SDRAM storage location */
 
-    /* DFU Configuration */
-      
-    /* 
-        If boot device detection is on, we want to be able to replace the target
-        devices with the detected boot device.  So the string should contain
-        fprintf style identifies everywhere the target device shows up.  We're
-        leaving this as a default environment variable so it can be modified by
-        user on a running system if desired.
-    */        
-    #ifdef CONFIG_BOOTDEV_DETECT
-        #define DFU_ALT_INFO_MMC \
-            "dfu_alt_info_mmc=" \
-	        "kernel fat %1d 1;" \
-	        "rootfs part %1d 2;" \
-	        "pumpkin-mbm2.dtb fat %1d 1" \
-	        "\0"
-    #else
-        #define DFU_ALT_INFO_MMC \
-	        "dfu_alt_info_mmc=" \
-	        "kernel fat 1 1;" \
-	        "rootfs part 1 2;" \
-	        "uboot fat 1 1;" \
-	        "pumpkin-mbm2.dtb fat 1 1" \
-	        "\0"
-    #endif
-    #define DFU_ALT_INFO_NOR ""
+/* DFU Configuration */
+
+/*
+    If boot device detection is on, we want to be able to replace the target
+    devices with the detected boot device.  So the string should contain
+    fprintf style identifies everywhere the target device shows up.  We're
+    leaving this as a default environment variable so it can be modified by
+    user on a running system if desired.
+*/
+#ifdef CONFIG_BOOTDEV_DETECT
+#define DFU_ALT_INFO_MMC         \
+    "dfu_alt_info_mmc="          \
+    "kernel fat %1d 1;"          \
+    "rootfs part %1d 2;"         \
+    "pumpkin-mbm2.dtb fat %1d 1" \
+    "\0"
 #else
-    #define DFU_ALT_INFO_MMC ""
-    #define DFU_ALT_INFO_NOR ""
+#define DFU_ALT_INFO_MMC       \
+    "dfu_alt_info_mmc="        \
+    "kernel fat 1 1;"          \
+    "rootfs part 1 2;"         \
+    "uboot fat 1 1;"           \
+    "pumpkin-mbm2.dtb fat 1 1" \
+    "\0"
+#endif
+#define DFU_ALT_INFO_NOR ""
+#else
+#define DFU_ALT_INFO_MMC ""
+#define DFU_ALT_INFO_NOR ""
 #endif /* CONFIG_UPDATE_KUBOS */
 
 #define CONFIG_BOOTCOMMAND \
     "run distro_bootcmd"
-    
-/* 
+
+/*
     This defines several boot commands that use different devices for loading
     the linux rootfs.  It also makes an ordered list in which they are attempted
-    by distro_bootcmd.  The order is top to bottom.  The standard LEGACY_MMC 
-    templates are defined in am335x_evm.h, but here we want to add a format 
-    that reads an environment parameter to uses it for device on which the 
-    rootfs resides. The new templates are named LEGACY_MMC_DEV and defined in 
+    by distro_bootcmd.  The order is top to bottom.  The standard LEGACY_MMC
+    templates are defined in am335x_evm.h, but here we want to add a format
+    that reads an environment parameter to uses it for device on which the
+    rootfs resides. The new templates are named LEGACY_MMC_DEV and defined in
     the first two macros below.
-*/   
+*/
 #define BOOTENV_DEV_LEGACY_MMC_ENV_PARAM(devtypeu, devtypel, envparam) \
-    "bootcmd_" #devtypel "=" \
-    "setenv mmcdev ${" #envparam "}; " \
-    "setenv bootpart ${" #envparam "}:2; " \
+    "bootcmd_" #devtypel "="                                           \
+    "setenv mmcdev ${" #envparam "}; "                                 \
+    "setenv bootpart ${" #envparam "}:2; "                             \
     "run mmcboot\0"
 
 #define BOOTENV_DEV_NAME_LEGACY_MMC_ENV_PARAM(devtypeu, devtypel, envparam) \
     #devtypel " "
-   
+
 #ifdef CONFIG_BOOTDEV_DETECT
-    #define BOOT_TARGET_DEVICES(func) \
-        func(LEGACY_MMC_ENV_PARAM, legacy_mmc_boot_detect, boot_detect) \
-        func(LEGACY_MMC_ENV_PARAM, legacy_mmc_boot_dev, boot_dev) \
-        func(LEGACY_MMC, legacy_mmc, 0) \
-        func(LEGACY_MMC, legacy_mmc, 1)
+#define BOOT_TARGET_DEVICES(func)                                   \
+    func(LEGACY_MMC_ENV_PARAM, legacy_mmc_boot_detect, boot_detect) \
+        func(LEGACY_MMC_ENV_PARAM, legacy_mmc_boot_dev, boot_dev)   \
+            func(LEGACY_MMC, legacy_mmc, 0)                         \
+                func(LEGACY_MMC, legacy_mmc, 1)
 #else
-    #define BOOT_TARGET_DEVICES(func) \
-        func(LEGACY_MMC_ENV_PARAM, legacy_mmc_dev, boot_dev) \
-        func(LEGACY_MMC, legacy_mmc, 0) \
-        func(LEGACY_MMC, legacy_mmc, 1)
+#define BOOT_TARGET_DEVICES(func)                        \
+    func(LEGACY_MMC_ENV_PARAM, legacy_mmc_dev, boot_dev) \
+        func(LEGACY_MMC, legacy_mmc, 0)                  \
+            func(LEGACY_MMC, legacy_mmc, 1)
 #endif
 
 /* Make sure our full U-Boot build has a comprehensive environment */
 #ifndef CONFIG_SPL_BUILD
-    #define CONFIG_EXTRA_ENV_SETTINGS \
-        DEFAULT_LINUX_BOOT_ENV \
-        "args_mmc=run finduuid;setenv bootargs console=${console} " \
-            "${optargs} " \
-            "root=/dev/mmcblk${mmcdev}p2 ro " \
-            "rootfstype=${mmcrootfstype}\0" \
-        "bootfile=kernel\0" \
-        "boot_dev=0\0" \
-        "console=ttyS0,115200\0" \
-        "fdtfile=pumpkin-mbm2.dtb\0" \
-        "finduuid=part uuid mmc ${bootpart} uuid\0" \
-        "loadimage=fatload mmc ${mmcdev}:1 ${loadaddr} /${bootfile}\0" \
-        "loadfdt=fatload mmc ${mmcdev}:1 ${fdtaddr} /${fdtfile}\0" \
-        "mmcdev=0\0" \
-        "mmcrootfstype=ext4 rootwait\0" \
-        "mmcloados=run args_mmc; " \
-            "if run loadfdt; then " \
-                "bootm ${loadaddr} - ${fdtaddr}; " \
-            "else " \
-                "echo ERROR: Failed to load FTD file ${fdtfile}; " \
-            "fi;\0" \
-        "mmcboot=mmc dev ${mmcdev}; " \
-            "if mmc rescan; then " \
-                "echo SD/MMC found on device ${mmcdev};" \
-                "if run loadimage; then " \
-                    "run mmcloados;" \
-                "fi;" \
-            "fi;\0" \
-        "optargs=\0" \
-	    NETARGS \
-	    BOOTENV \
-	    KUBOS_UPDATE_ARGS
+#define CONFIG_EXTRA_ENV_SETTINGS                                  \
+    DEFAULT_LINUX_BOOT_ENV                                         \
+    "args_mmc=run finduuid;setenv bootargs console=${console} "    \
+    "${optargs} "                                                  \
+    "root=/dev/mmcblk${mmcdev}p2 ro "                              \
+    "rootfstype=${mmcrootfstype}\0"                                \
+    "bootfile=kernel\0"                                            \
+    "boot_dev=0\0"                                                 \
+    "console=ttyS0,115200\0"                                       \
+    "fdtfile=pumpkin-mbm2.dtb\0"                                   \
+    "finduuid=part uuid mmc ${bootpart} uuid\0"                    \
+    "loadimage=fatload mmc ${mmcdev}:1 ${loadaddr} /${bootfile}\0" \
+    "loadfdt=fatload mmc ${mmcdev}:1 ${fdtaddr} /${fdtfile}\0"     \
+    "mmcdev=0\0"                                                   \
+    "mmcrootfstype=ext4 rootwait\0"                                \
+    "mmcloados=run args_mmc; "                                     \
+    "if run loadfdt; then "                                        \
+    "bootm ${loadaddr} - ${fdtaddr}; "                             \
+    "else "                                                        \
+    "echo ERROR: Failed to load FTD file ${fdtfile}; "             \
+    "fi;\0"                                                        \
+    "mmcboot=mmc dev ${mmcdev}; "                                  \
+    "if mmc rescan; then "                                         \
+    "echo SD/MMC found on device ${mmcdev};"                       \
+    "if run loadimage; then "                                      \
+    "run mmcloados;"                                               \
+    "fi;"                                                          \
+    "fi;\0"                                                        \
+    "optargs=\0" NETARGS                                           \
+        BOOTENV                                                    \
+            KUBOS_UPDATE_ARGS
 #endif
-


### PR DESCRIPTION
adds support for separate envar partition where uboot.env is stored.
Default partition is 5 since adding a partition on the genimage.cfg for buildroot creates a new logical partition.

apparently my vscode auto-formatted all these files too.